### PR TITLE
Add pytest support with parsing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
+## Pruebas
+
+Ejecuta los tests unitarios con:
+
+```bash
+pytest -q
+```
+
 ## Deploy en Streamlit Cloud
 1. Crea un repo en GitHub y sube estos archivos tal cual.
 2. Ve a https://share.streamlit.io , conecta tu repo y selecciona `app.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tldextract==5.1.2
 scikit-learn==1.5.1
 rapidfuzz==3.9.6
 pyyaml==6.0.2
+pytest==8.4.1

--- a/tests/test_web_ingestor.py
+++ b/tests/test_web_ingestor.py
@@ -1,0 +1,56 @@
+import re
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from web_ingestor import parse_product_page, classify_by_thresholds
+
+
+def test_classify_by_thresholds_selects_correct_class():
+    thresholds = [
+        {"kg_min": 5, "clase": "XL"},
+        {"kg_min": 0, "clase": "XS"},
+        {"kg_min": 1, "clase": "S"},
+    ]
+    assert classify_by_thresholds(2, thresholds) == "S"
+    assert classify_by_thresholds(None, thresholds) == ""
+
+
+def test_parse_product_page_jsonld_dimensions_and_classification():
+    html = """
+    <html><head><title>dummy</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "Test Widget",
+      "brand": {"name": "WidgetCo"},
+      "weight": {"value": "1.5", "unitCode": "KGM"},
+      "additionalProperty": [
+        {"name": "Largo", "value": "20"},
+        {"name": "Ancho", "value": "10"},
+        {"name": "Alto", "value": "5"}
+      ]
+    }
+    </script>
+    </head><body></body></html>
+    """
+    thresholds = [
+        {"kg_min": 0, "clase": "XS"},
+        {"kg_min": 1, "clase": "M"},
+        {"kg_min": 2, "clase": "L"},
+    ]
+    row = parse_product_page(html, "https://example.com/product", thresholds, divisor_vol=5000)
+
+    assert row["product_name"] == "Test Widget"
+    assert row["brand"] == "WidgetCo"
+    assert row["peso_kg"] == 1.5
+    assert row["largo_cm"] == 20.0
+    assert row["ancho_cm"] == 10.0
+    assert row["alto_cm"] == 5.0
+    assert row["peso_vol_kg"] == 0.2
+    assert row["peso_fact_kg"] == 1.5
+    assert row["clase_logistica"] == "M"
+    assert re.fullmatch(r"[0-9a-f]{64}", row["hash_row"])


### PR DESCRIPTION
## Summary
- add pytest dependency and document test command
- implement unit tests for `classify_by_thresholds` and `parse_product_page`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84ff2baf8832ab4cf44cfae2dde26