### PR TITLE
Enable broad web crawling via search

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ App en **Streamlit** que:
 ├── app.py
 ├── web_ingestor.py
 ├── parametros_logistica.json
-├── sources.yml
 ├── requirements.txt
 └── .streamlit/config.toml
 ```
@@ -35,10 +34,9 @@ pytest -q
 ## Deploy en Streamlit Cloud
 1. Crea un repo en GitHub y sube estos archivos tal cual.
 2. Ve a https://share.streamlit.io , conecta tu repo y selecciona `app.py`.
-3. (Opcional) Edita `sources.yml` en el repo para definir tus dominios.
-4. Dentro de la app, usa **“🚀 Ejecutar ingesta web ahora”** para poblar el diccionario.
+3. Dentro de la app, ajusta el término de búsqueda y usa **“🚀 Ejecutar ingesta web ahora”** para poblar el diccionario.
 
 ## Notas de cumplimiento
 - La ingesta respeta **robots.txt** y aplica **delay** entre requests.
 - La app solo extrae metadatos visibles públicamente (JSON-LD Product / OpenGraph).
-- Ajusta `sources.yml` para incluir únicamente dominios que tengas permiso de explorar.
+- Se recomienda usar términos de búsqueda relacionados con sitios que tengas permiso de explorar.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
 \
 import streamlit as st
 import pandas as pd
-import json, os, time, io, yaml
+import json, os, time, io
 import numpy as np
 import threading
-from web_ingestor import crawl_domain
+from web_ingestor import crawl_web
 from scheduler import schedule_crawl
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report, accuracy_score
@@ -17,7 +17,6 @@ from rapidfuzz import process, fuzz
 import db
 
 DEFAULT_PARAMS_PATH = "parametros_logistica.json"
-DEFAULT_SOURCES_YML = "sources.yml"
 
 @st.cache_data(show_spinner=False)
 def load_params(path=DEFAULT_PARAMS_PATH):
@@ -37,29 +36,25 @@ def load_params(path=DEFAULT_PARAMS_PATH):
         ],
     }
 
-@st.cache_data(show_spinner=False)
-def load_sources(path=DEFAULT_SOURCES_YML):
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
-            y = yaml.safe_load(f)
-            return y.get("sources", []), y.get("max_pages_per_domain", 25), y.get("delay_seconds", 1.0)
-    return [], 25, 1.0
 
 def save_params(params, path=DEFAULT_PARAMS_PATH):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(params, f, ensure_ascii=False, indent=2)
 
-def save_sources(sources, max_pages, delay, path=DEFAULT_SOURCES_YML):
-    y = {"sources": sources, "max_pages_per_domain": max_pages, "delay_seconds": delay}
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(yaml.safe_dump(y, sort_keys=False, allow_unicode=True))
 
 st.set_page_config(page_title="Clasificador Logístico Ripley", page_icon="📦", layout="wide")
 st.title("📦 Clasificador de Clase Logística (auto-ingesta web)")
 st.caption("Crawling legal (robots.txt), reglas por peso/volumen, diccionario vivo y baseline ML.")
 
 params = load_params()
-sources, max_pages, delay = load_sources()
+
+# Estado inicial para búsqueda web
+if "search_query" not in st.session_state:
+    st.session_state.search_query = "producto"
+if "max_pages" not in st.session_state:
+    st.session_state.max_pages = 25
+if "delay" not in st.session_state:
+    st.session_state.delay = 1.0
 
 # Inicializar base de datos y cargar diccionario
 db.init_db()
@@ -87,7 +82,14 @@ def start_scheduler():
     st.session_state.scheduler_stop_event = threading.Event()
     t = threading.Thread(
         target=schedule_crawl,
-        args=(st.session_state.scheduler_interval, merge_rows, st.session_state.scheduler_stop_event),
+        args=(
+            st.session_state.scheduler_interval,
+            st.session_state.search_query,
+            int(st.session_state.max_pages),
+            float(st.session_state.delay),
+            merge_rows,
+            st.session_state.scheduler_stop_event,
+        ),
         daemon=True,
     )
     st.session_state.scheduler_thread = t
@@ -98,7 +100,7 @@ def stop_scheduler():
         st.session_state.scheduler_stop_event.set()
         st.session_state.scheduler_thread = None
 
-# Sidebar: parámetros y fuentes
+# Sidebar: parámetros
 with st.sidebar:
     st.header("⚙️ Parámetros")
     params["divisor_volumetrico"] = st.number_input("Divisor volumétrico (cm)", value=int(params["divisor_volumetrico"]), step=100)
@@ -110,21 +112,29 @@ with st.sidebar:
         save_params(params)
         st.success("Parámetros guardados.")
 
-    st.header("🌐 Fuentes (dominios)")
-    st.caption("La app explorará estos dominios respetando robots.txt y límites.")
-    src_text = st.text_area("Dominios (uno por línea)", value="\n".join(sources), height=150)
-    colA, colB = st.columns(2)
-    with colA:
-        max_pages = st.number_input("Máx. páginas por dominio", value=int(max_pages), min_value=5, step=5)
-    with colB:
-        delay = st.number_input("Delay entre requests (seg)", value=float(delay), min_value=0.5, step=0.5)
-    if st.button("💾 Guardar fuentes", use_container_width=True, key="save_sources"):
-        new_sources = [s.strip() for s in src_text.splitlines() if s.strip()]
-        save_sources(new_sources, max_pages, delay)
-        st.success("Fuentes guardadas.")
-
 st.subheader("1) 📥 Ingesta automática desde la web (crawler)")
-st.write("La app recorrerá cada dominio y extraerá fichas de producto con **JSON-LD Product** cuando existan.")
+st.write("La app buscará en la web páginas que contengan metadatos **JSON-LD Product**.")
+
+st.session_state.search_query = st.text_input(
+    "Término de búsqueda web",
+    value=st.session_state.search_query,
+    help="Se usará DuckDuckGo para descubrir URLs iniciales",
+)
+colA, colB = st.columns(2)
+with colA:
+    st.session_state.max_pages = st.number_input(
+        "Máx. páginas a explorar",
+        value=int(st.session_state.max_pages),
+        min_value=5,
+        step=5,
+    )
+with colB:
+    st.session_state.delay = st.number_input(
+        "Delay entre requests (seg)",
+        value=float(st.session_state.delay),
+        min_value=0.5,
+        step=0.5,
+    )
 
 st.markdown("**Programar ingesta periódica**")
 st.session_state.scheduler_interval = st.number_input(
@@ -161,20 +171,21 @@ with col3:
         start_scheduler()
 
 if st.button("🚀 Ejecutar ingesta web ahora", use_container_width=True):
-    sources, max_pages, delay = load_sources()
-    progress = st.progress(0.0, text="Iniciando...")
-    all_rows = []
-    for i, domain in enumerate(sources):
-        progress.progress((i)/max(1, len(sources)), text=f"Crawling: {domain}")
-        try:
-            rows = crawl_domain(domain, params["clases_por_peso"], params["divisor_volumetrico"], max_pages=max_pages, delay=delay)
-            all_rows.extend(rows)
-        except Exception as e:
-            st.warning(f"Error en {domain}: {e}")
+    progress = st.progress(0.0, text=f"Buscando: {st.session_state.search_query}")
+    try:
+        rows = crawl_web(
+            st.session_state.search_query,
+            params["clases_por_peso"],
+            params["divisor_volumetrico"],
+            max_pages=int(st.session_state.max_pages),
+            delay=float(st.session_state.delay),
+        )
+    except Exception as e:
+        rows = []
+        st.warning(f"Error: {e}")
     progress.progress(1.0, text="Completado.")
-    if all_rows:
-        new_df = pd.DataFrame(all_rows)
-        # de-dup por hash_row
+    if rows:
+        new_df = pd.DataFrame(rows)
         merged = pd.concat([st.session_state.dict_df, new_df], ignore_index=True)
         merged = merged.drop_duplicates(subset=["hash_row"], keep="first")
         st.session_state.dict_df = merged
@@ -182,7 +193,7 @@ if st.button("🚀 Ejecutar ingesta web ahora", use_container_width=True):
             db.upsert_product(row.to_dict())
         st.success(f"Ingesta completa. Nuevos registros: {len(new_df)} | Total en diccionario: {len(st.session_state.dict_df)}")
     else:
-        st.info("No se encontraron productos (revisa dominios, robots.txt o aumenta el límite de páginas).")
+        st.info("No se encontraron productos para la búsqueda indicada.")
 
 st.markdown("Vista del diccionario (primeros 200):")
 st.dataframe(st.session_state.dict_df.head(200), use_container_width=True, height=350)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ requests==2.32.3
 tldextract==5.1.2
 scikit-learn==1.5.1
 rapidfuzz==3.9.6
-pyyaml==6.0.2
 pytest==8.4.1
 tensorflow==2.16.2
 keras==3.3.3

--- a/sources.yml
+++ b/sources.yml
@@ -1,7 +1,0 @@
-# Lista inicial de dominios permitidos para ingesta automática.
-# La app respeta robots.txt y limita el número de páginas.
-sources:
-  - https://www.openfoodfacts.org/ # dataset público para prueba (solo demo)
-  - https://www.example.com/       # reemplaza con dominios de sellers permitidos
-max_pages_per_domain: 25
-delay_seconds: 1.0

--- a/tests/test_web_ingestor.py
+++ b/tests/test_web_ingestor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 # Ensure the repository root is on the import path for direct module imports
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from web_ingestor import parse_product_page, classify_by_thresholds
+from web_ingestor import parse_product_page, classify_by_thresholds, find_links
 
 
 def test_classify_by_thresholds_selects_correct_class():
@@ -54,3 +54,17 @@ def test_parse_product_page_jsonld_dimensions_and_classification():
     assert row["peso_fact_kg"] == 1.5
     assert row["clase_logistica"] == "M"
     assert re.fullmatch(r"[0-9a-f]{64}", row["hash_row"])
+
+
+def test_find_links_cross_domain_option():
+    html = (
+        '<a href="http://example.com/a">A</a>'
+        '<a href="http://other.com/b">B</a>'
+    )
+    base = "http://example.com"
+    same = find_links(html, base, same_domain_only=True)
+    assert "http://example.com/a" in same
+    assert "http://other.com/b" not in same
+    wide = find_links(html, base, same_domain_only=False)
+    assert "http://example.com/a" in wide
+    assert "http://other.com/b" in wide


### PR DESCRIPTION
## Summary
- allow cross-domain link extraction and add DuckDuckGo search to seed crawling
- switch UI and scheduler to use search queries instead of domain lists
- remove `sources.yml` and unused YAML dependency

## Testing
- `python -m py_compile web_ingestor.py app.py scheduler.py db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b857b41808832ab058829cac5c3256