### PR TITLE
Prevent TypeError when scheduler hasn't started

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,7 +148,10 @@ with col1:
     if st.button(
         "▶️ Iniciar scheduler",
         use_container_width=True,
-        disabled=st.session_state.scheduler_thread and st.session_state.scheduler_thread.is_alive(),
+        disabled=(
+            st.session_state.scheduler_thread is not None
+            and st.session_state.scheduler_thread.is_alive()
+        ),
         key="start_sched",
     ):
         start_scheduler()


### PR DESCRIPTION
## Summary
- Ensure "Iniciar scheduler" button receives a boolean `disabled` value
- Avoid Streamlit TypeError when no scheduler thread exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b859cf0a34832a96e78d5c98bb830f