### PR TITLE
Add minimal mode toggle to streamline UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,19 +100,27 @@ def stop_scheduler():
         st.session_state.scheduler_stop_event.set()
         st.session_state.scheduler_thread = None
 
-# Sidebar: parámetros
+# Sidebar minimalista con opciones avanzadas
 with st.sidebar:
-    st.header("⚙️ Parámetros")
-    params["divisor_volumetrico"] = st.number_input("Divisor volumétrico (cm)", value=int(params["divisor_volumetrico"]), step=100)
-    thr_df = pd.DataFrame(params["clases_por_peso"])
-    st.markdown("**Umbrales (kg_min → clase)**")
-    thr_df = st.data_editor(thr_df, num_rows="dynamic", use_container_width=True, key="thr")
-    params["clases_por_peso"] = thr_df.sort_values("kg_min", ascending=True).to_dict(orient="records")
-    if st.button("💾 Guardar parámetros", use_container_width=True):
-        save_params(params)
-        st.success("Parámetros guardados.")
+    show_advanced = st.checkbox("Mostrar opciones avanzadas")
+    if show_advanced:
+        st.header("⚙️ Parámetros")
+        params["divisor_volumetrico"] = st.number_input(
+            "Divisor volumétrico (cm)", value=int(params["divisor_volumetrico"]), step=100
+        )
+        thr_df = pd.DataFrame(params["clases_por_peso"])
+        st.markdown("**Umbrales (kg_min → clase)**")
+        thr_df = st.data_editor(
+            thr_df, num_rows="dynamic", use_container_width=True, key="thr"
+        )
+        params["clases_por_peso"] = (
+            thr_df.sort_values("kg_min", ascending=True).to_dict(orient="records")
+        )
+        if st.button("💾 Guardar parámetros", use_container_width=True):
+            save_params(params)
+            st.success("Parámetros guardados.")
 
-st.subheader("1) 📥 Ingesta automática desde la web (crawler)")
+st.subheader("📥 Ingesta automática desde la web (crawler)")
 st.write("La app buscará en la web páginas que contengan metadatos **JSON-LD Product**.")
 
 st.session_state.search_query = st.text_input(
@@ -136,42 +144,49 @@ with colB:
         step=0.5,
     )
 
-st.markdown("**Programar ingesta periódica**")
-st.number_input(
-    "Frecuencia de ejecución (horas)",
-    min_value=1,
-    value=int(st.session_state.scheduler_interval),
-    key="scheduler_interval",
-)
-col1, col2, col3 = st.columns(3)
-with col1:
-    if st.button(
-        "▶️ Iniciar scheduler",
-        use_container_width=True,
-        disabled=(
-            st.session_state.scheduler_thread is not None
-            and st.session_state.scheduler_thread.is_alive()
-        ),
-        key="start_sched",
-    ):
-        start_scheduler()
-with col2:
-    if st.button(
-        "⏹️ Detener scheduler",
-        use_container_width=True,
-        disabled=not (st.session_state.scheduler_thread and st.session_state.scheduler_thread.is_alive()),
-        key="stop_sched",
-    ):
-        stop_scheduler()
-with col3:
-    if st.button(
-        "🔄 Reiniciar scheduler",
-        use_container_width=True,
-        disabled=not (st.session_state.scheduler_thread and st.session_state.scheduler_thread.is_alive()),
-        key="restart_sched",
-    ):
-        stop_scheduler()
-        start_scheduler()
+if show_advanced:
+    st.markdown("**Programar ingesta periódica**")
+    st.number_input(
+        "Frecuencia de ejecución (horas)",
+        min_value=1,
+        value=int(st.session_state.scheduler_interval),
+        key="scheduler_interval",
+    )
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        if st.button(
+            "▶️ Iniciar scheduler",
+            use_container_width=True,
+            disabled=(
+                st.session_state.scheduler_thread is not None
+                and st.session_state.scheduler_thread.is_alive()
+            ),
+            key="start_sched",
+        ):
+            start_scheduler()
+    with col2:
+        if st.button(
+            "⏹️ Detener scheduler",
+            use_container_width=True,
+            disabled=not (
+                st.session_state.scheduler_thread
+                and st.session_state.scheduler_thread.is_alive()
+            ),
+            key="stop_sched",
+        ):
+            stop_scheduler()
+    with col3:
+        if st.button(
+            "🔄 Reiniciar scheduler",
+            use_container_width=True,
+            disabled=not (
+                st.session_state.scheduler_thread
+                and st.session_state.scheduler_thread.is_alive()
+            ),
+            key="restart_sched",
+        ):
+            stop_scheduler()
+            start_scheduler()
 
 if st.button("🚀 Ejecutar ingesta web ahora", use_container_width=True):
     progress = st.progress(0.0, text=f"Buscando: {st.session_state.search_query}")
@@ -201,126 +216,146 @@ if st.button("🚀 Ejecutar ingesta web ahora", use_container_width=True):
 st.markdown("Vista del diccionario (primeros 200):")
 st.dataframe(st.session_state.dict_df.head(200), use_container_width=True, height=350)
 
-st.subheader("2) 🔎 Búsqueda automática por título")
-q = st.text_input("Título del producto")
-if st.button("Buscar y aprender", use_container_width=True) and q:
-    progress = st.progress(0.0, text=f"Buscando: {q}")
-    try:
-        rows = crawl_web(
-            q,
-            params["clases_por_peso"],
-            params["divisor_volumetrico"],
-            max_pages=int(st.session_state.max_pages),
-            delay=float(st.session_state.delay),
-        )
-    except Exception as e:
-        rows = []
-        st.warning(f"Error: {e}")
-    progress.progress(1.0, text="Completado.")
-    if rows:
-        new_df = pd.DataFrame(rows)
-        merged = pd.concat([st.session_state.dict_df, new_df], ignore_index=True)
-        merged = merged.drop_duplicates(subset=["hash_row"], keep="first")
-        st.session_state.dict_df = merged
-        for _, row in new_df.iterrows():
-            db.upsert_product(row.to_dict())
-        st.success(
-            f"Se agregaron {len(new_df)} productos al diccionario. Total: {len(st.session_state.dict_df)}"
-        )
-    else:
-        st.info("No se encontraron productos en la web para este título.")
-
-if q:
-    names = st.session_state.dict_df["product_name"].fillna("").tolist()
-    matches = process.extract(q, names, scorer=fuzz.WRatio, limit=10)
-    idxs = []
-    for m, score, pos in matches:
-        idx = st.session_state.dict_df.index[
-            st.session_state.dict_df["product_name"] == m
-        ].tolist()
-        if idx:
-            idxs.append(idx[0])
-    res = st.session_state.dict_df.loc[idxs] if idxs else pd.DataFrame()
-    st.caption(f"Top {len(res)} resultados (fuzzy):")
-    st.dataframe(res, use_container_width=True)
-
-    if not res.empty:
-        sel = st.selectbox("Selecciona fila para editar", res.index.tolist())
-        if sel is not None:
-            edit_row = st.session_state.dict_df.loc[sel].to_dict()
-            st.write("**Detalle seleccionado**")
-            st.json(edit_row)
-            classes = [c["clase"] for c in params["clases_por_peso"]]
-            new_class = st.selectbox(
-                "Editar clase",
-                classes,
-                index=max(
-                    0,
-                    classes.index(edit_row.get("clase_logistica"))
-                    if edit_row.get("clase_logistica") in classes
-                    else 0,
-                ),
+if show_advanced:
+    st.subheader("🔎 Búsqueda automática por título")
+    q = st.text_input("Título del producto")
+    if st.button("Buscar y aprender", use_container_width=True) and q:
+        progress = st.progress(0.0, text=f"Buscando: {q}")
+        try:
+            rows = crawl_web(
+                q,
+                params["clases_por_peso"],
+                params["divisor_volumetrico"],
+                max_pages=int(st.session_state.max_pages),
+                delay=float(st.session_state.delay),
             )
-            if st.button("💾 Guardar cambios en fila seleccionada"):
-                st.session_state.dict_df.at[sel, "clase_logistica"] = new_class
-                db.upsert_product(st.session_state.dict_df.loc[sel].to_dict())
-                st.success("Actualizado.")
+        except Exception as e:
+            rows = []
+            st.warning(f"Error: {e}")
+        progress.progress(1.0, text="Completado.")
+        if rows:
+            new_df = pd.DataFrame(rows)
+            merged = pd.concat([st.session_state.dict_df, new_df], ignore_index=True)
+            merged = merged.drop_duplicates(subset=["hash_row"], keep="first")
+            st.session_state.dict_df = merged
+            for _, row in new_df.iterrows():
+                db.upsert_product(row.to_dict())
+            st.success(
+                f"Se agregaron {len(new_df)} productos al diccionario. Total: {len(st.session_state.dict_df)}"
+            )
+        else:
+            st.info("No se encontraron productos en la web para este título.")
 
-st.subheader("3) ⬇️ Exportar diccionario")
+    if q:
+        names = st.session_state.dict_df["product_name"].fillna("").tolist()
+        matches = process.extract(q, names, scorer=fuzz.WRatio, limit=10)
+        idxs = []
+        for m, score, pos in matches:
+            idx = st.session_state.dict_df.index[
+                st.session_state.dict_df["product_name"] == m
+            ].tolist()
+            if idx:
+                idxs.append(idx[0])
+        res = st.session_state.dict_df.loc[idxs] if idxs else pd.DataFrame()
+        st.caption(f"Top {len(res)} resultados (fuzzy):")
+        st.dataframe(res, use_container_width=True)
+
+        if not res.empty:
+            sel = st.selectbox("Selecciona fila para editar", res.index.tolist())
+            if sel is not None:
+                edit_row = st.session_state.dict_df.loc[sel].to_dict()
+                st.write("**Detalle seleccionado**")
+                st.json(edit_row)
+                classes = [c["clase"] for c in params["clases_por_peso"]]
+                new_class = st.selectbox(
+                    "Editar clase",
+                    classes,
+                    index=max(
+                        0,
+                        classes.index(edit_row.get("clase_logistica"))
+                        if edit_row.get("clase_logistica") in classes
+                        else 0,
+                    ),
+                )
+                if st.button("💾 Guardar cambios en fila seleccionada"):
+                    st.session_state.dict_df.at[sel, "clase_logistica"] = new_class
+                    db.upsert_product(st.session_state.dict_df.loc[sel].to_dict())
+                    st.success("Actualizado.")
+
+st.subheader("⬇️ Exportar diccionario")
 export_df = db.load_dictionary()
 csv_data = export_df.to_csv(index=False).encode("utf-8")
 st.download_button("Descargar CSV", csv_data, file_name="diccionario_logistica.csv", mime="text/csv")
 
-st.divider()
-st.subheader("4) 🔬 (Opcional) Entrenar baseline ML (texto → clase)")
-ml_df = st.session_state.dict_df.dropna(subset=["product_name","clase_logistica"])
-enough = ml_df["clase_logistica"].nunique() >= 2 and len(ml_df) >= 50
-st.caption("Usa los datos del diccionario (con tus correcciones). Se requiere ≥50 filas y ≥2 clases.")
-if st.button("Entrenar modelo", disabled=not enough):
-    try:
-        X_train, X_test, y_train, y_test = train_test_split(
-            ml_df["product_name"], ml_df["clase_logistica"], test_size=0.2,
-            random_state=42, stratify=ml_df["clase_logistica"]
-        )
-
-        tokenizer = Tokenizer(num_words=10000, oov_token="<OOV>")
-        tokenizer.fit_on_texts(X_train)
-        maxlen = 20
-        Xtr = pad_sequences(tokenizer.texts_to_sequences(X_train), maxlen=maxlen, padding="post")
-        Xte = pad_sequences(tokenizer.texts_to_sequences(X_test), maxlen=maxlen, padding="post")
-
-        le = LabelEncoder()
-        y_train_enc = le.fit_transform(y_train)
-
-        model = Sequential([
-            Embedding(input_dim=10000, output_dim=16, input_length=maxlen),
-            GlobalAveragePooling1D(),
-            Dense(len(le.classes_), activation="softmax"),
-        ])
-        model.compile(optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"])
-        model.fit(Xtr, y_train_enc, epochs=10, verbose=0)
-
-        y_pred_enc = np.argmax(model.predict(Xte), axis=1)
-        y_pred = le.inverse_transform(y_pred_enc)
-        st.write("**Accuracy:**", round(accuracy_score(y_test, y_pred), 4))
-        st.text(classification_report(y_test, y_pred))
-
-        st.session_state.ml_tokenizer = tokenizer
-        st.session_state.ml_model = model
-        st.session_state.ml_le = le
-        st.session_state.ml_maxlen = maxlen
-        st.success("Modelo entrenado en memoria.")
-    except Exception as e:
-        st.error(f"Error entrenando modelo: {e}")
-
-test_text = st.text_input("Probar predicción ML (nombre de producto)")
-if test_text and "ml_model" in st.session_state:
-    seq = pad_sequences(
-        st.session_state.ml_tokenizer.texts_to_sequences([test_text]),
-        maxlen=st.session_state.ml_maxlen, padding="post"
+if show_advanced:
+    st.divider()
+    st.subheader("🔬 (Opcional) Entrenar baseline ML (texto → clase)")
+    ml_df = st.session_state.dict_df.dropna(
+        subset=["product_name", "clase_logistica"]
     )
-    pred_enc = np.argmax(st.session_state.ml_model.predict(seq), axis=1)
-    pred = st.session_state.ml_le.inverse_transform(pred_enc)[0]
-    st.info(f"Predicción de clase: **{pred}**")
-elif test_text:
-    st.warning("Entrena el modelo primero.")
+    enough = ml_df["clase_logistica"].nunique() >= 2 and len(ml_df) >= 50
+    st.caption(
+        "Usa los datos del diccionario (con tus correcciones). Se requiere ≥50 filas y ≥2 clases."
+    )
+    if st.button("Entrenar modelo", disabled=not enough):
+        try:
+            X_train, X_test, y_train, y_test = train_test_split(
+                ml_df["product_name"],
+                ml_df["clase_logistica"],
+                test_size=0.2,
+                random_state=42,
+                stratify=ml_df["clase_logistica"],
+            )
+
+            tokenizer = Tokenizer(num_words=10000, oov_token="<OOV>")
+            tokenizer.fit_on_texts(X_train)
+            maxlen = 20
+            Xtr = pad_sequences(
+                tokenizer.texts_to_sequences(X_train), maxlen=maxlen, padding="post"
+            )
+            Xte = pad_sequences(
+                tokenizer.texts_to_sequences(X_test), maxlen=maxlen, padding="post"
+            )
+
+            le = LabelEncoder()
+            y_train_enc = le.fit_transform(y_train)
+
+            model = Sequential(
+                [
+                    Embedding(input_dim=10000, output_dim=16, input_length=maxlen),
+                    GlobalAveragePooling1D(),
+                    Dense(len(le.classes_), activation="softmax"),
+                ]
+            )
+            model.compile(
+                optimizer="adam",
+                loss="sparse_categorical_crossentropy",
+                metrics=["accuracy"],
+            )
+            model.fit(Xtr, y_train_enc, epochs=10, verbose=0)
+
+            y_pred_enc = np.argmax(model.predict(Xte), axis=1)
+            y_pred = le.inverse_transform(y_pred_enc)
+            st.write("**Accuracy:**", round(accuracy_score(y_test, y_pred), 4))
+            st.text(classification_report(y_test, y_pred))
+
+            st.session_state.ml_tokenizer = tokenizer
+            st.session_state.ml_model = model
+            st.session_state.ml_le = le
+            st.session_state.ml_maxlen = maxlen
+            st.success("Modelo entrenado en memoria.")
+        except Exception as e:
+            st.error(f"Error entrenando modelo: {e}")
+
+    test_text = st.text_input("Probar predicción ML (nombre de producto)")
+    if test_text and "ml_model" in st.session_state:
+        seq = pad_sequences(
+            st.session_state.ml_tokenizer.texts_to_sequences([test_text]),
+            maxlen=st.session_state.ml_maxlen,
+            padding="post",
+        )
+        pred_enc = np.argmax(st.session_state.ml_model.predict(seq), axis=1)
+        pred = st.session_state.ml_le.inverse_transform(pred_enc)[0]
+        st.info(f"Predicción de clase: **{pred}**")
+    elif test_text:
+        st.warning("Entrena el modelo primero.")


### PR DESCRIPTION
## Summary
- Add sidebar toggle to show or hide advanced options
- Hide scheduler, search, and ML training behind the advanced toggle for a simpler default layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85e0bc034832a9f9b1b910e4b4068